### PR TITLE
CASMPET-5268 Update how chart version is set

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -15,7 +15,7 @@ pipeline {
         DESCRIPTION = "HPE TrustedCerts K8S Operator"
         IS_STABLE = getBuildIsStable()
         VERSION = getDockerBuildVersion(isStable: env.IS_STABLE)
-        CHART_VERSION = getChartVersion(version: env.VERSION)
+        CHART_VERSION = getChartVersion(name: env.NAME, isStable: env.IS_STABLE)
         DOCKER_ARGS = getDockerBuildArgs(name: env.NAME, description: env.DESCRIPTION)
     }
 

--- a/kubernetes/trustedcerts-operator/values.yaml
+++ b/kubernetes/trustedcerts-operator/values.yaml
@@ -23,7 +23,7 @@
 #
 image:
   repository: artifactory.algol60.net/csm-docker/stable/trustedcerts-operator
-  tag: 0.1.2
+  tag: 0.2.0
   pullPolicy: IfNotPresent
 
 # watchNamespaces must contain namespaces that the operator


### PR DESCRIPTION
## Summary and Scope

This fixes an issue where the chart version was overridden by the version stated in the .version file. This has been changed so that the chart is no longer coupled to the docker container.

## Issues and Related PRs

* Resolves [CASMPET-5268](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5268) 

## Testing

Validated that the chart built correctly.
