### PR TITLE
CASMINST-5896: Add CA configmap to argo namespace

### DIFF
--- a/kubernetes/trustedcerts-operator/Chart.yaml
+++ b/kubernetes/trustedcerts-operator/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: trustedcerts-operator
-version: 0.6.0
+version: 0.7.0
 description: TrustedCerts Operator
 keywords:
   - trustedcerts
@@ -34,3 +34,4 @@ maintainers:
   - name: kburns-hpe
 annotations:
   artifacthub.io/license: MIT
+appVersion: 0.3.0

--- a/kubernetes/trustedcerts-operator/templates/deployment.yaml
+++ b/kubernetes/trustedcerts-operator/templates/deployment.yaml
@@ -47,8 +47,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 75Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
       terminationGracePeriodSeconds: 10

--- a/kubernetes/trustedcerts-operator/templates/trustedcerts-shasta-1-3-compat.yaml
+++ b/kubernetes/trustedcerts-operator/templates/trustedcerts-shasta-1-3-compat.yaml
@@ -32,3 +32,10 @@ spec:
          namespace: opa
          encoding: "pem"
          bundle_key: "certificate_authority.crt" # key used to store 'bundle' of all certs
+    - name: argo
+      type: configmap
+      config:
+         name: cray-configmap-ca-public-key
+         namespace: argo
+         encoding: "pem"
+         bundle_key: "certificate_authority.crt" # key used to store 'bundle' of all certs

--- a/kubernetes/trustedcerts-operator/values.yaml
+++ b/kubernetes/trustedcerts-operator/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -36,3 +36,4 @@ watchNamespaces:
   - opa
   - services
   - sma
+  - argo


### PR DESCRIPTION
## Summary and Scope

Add CAs (via configmap) to `argo` namespace. 

## Issues and Related PRs

* Resolves [CASMINST-5896](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5896)
* Change will also be needed in `main`
* Future work required by [CASMINST-5898](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5898)
* Merge before 1.4 PRs associated with [CASMINST-5843](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5843) 

## Testing

Tested using local operator test (makefile based). Also deployed to `Frigg` system and verified. 

### Tested on:

  * `Frigg`
  * Local development environment

## Risks and Mitigations

Minimal risk. Just adds `argo` to list of namespaces to distribute CA configmap to. 

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
