### PR TITLE
Casmpet 6605 main

### DIFF
--- a/config/crd/bases/certificates.hpe.com_trustedcertificates.yaml
+++ b/config/crd/bases/certificates.hpe.com_trustedcertificates.yaml
@@ -1,6 +1,5 @@
-
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -17,80 +16,79 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      description: TrustedCertificates is the Schema for the trustedcertificates API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TrustedCertificatesSpec defines the desired state of TrustedCertificates
-          properties:
-            destinations:
-              items:
-                description: Destination Certificate destination struct
-                properties:
-                  config:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  name:
-                    maxLength: 255
-                    minLength: 1
-                    type: string
-                  type:
-                    pattern: (configmap|bss)
-                    type: string
-                required:
-                - config
-                - name
-                - type
-                type: object
-              minItems: 1
-              type: array
-            sources:
-              items:
-                description: Source Certificate source struct
-                properties:
-                  config:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  name:
-                    maxLength: 255
-                    minLength: 1
-                    type: string
-                  type:
-                    pattern: (http)
-                    type: string
-                required:
-                - config
-                - name
-                - type
-                type: object
-              minItems: 1
-              type: array
-          required:
-          - destinations
-          - sources
-          type: object
-        status:
-          description: TrustedCertificatesStatus defines the observed state of TrustedCertificates
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TrustedCertificates is the Schema for the trustedcertificates API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TrustedCertificatesSpec defines the desired state of TrustedCertificates
+            properties:
+              destinations:
+                items:
+                  description: Destination Certificate destination struct
+                  properties:
+                    config:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    name:
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    type:
+                      pattern: (configmap|bss)
+                      type: string
+                  required:
+                  - config
+                  - name
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+              sources:
+                items:
+                  description: Source Certificate source struct
+                  properties:
+                    config:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    name:
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    type:
+                      pattern: (http)
+                      type: string
+                  required:
+                  - config
+                  - name
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+            required:
+            - destinations
+            - sources
+            type: object
+          status:
+            description: TrustedCertificatesStatus defines the observed state of TrustedCertificates
+            type: object
+        type: object
     served: true
     storage: true
 status:

--- a/config/crd/patches/cainjection_in_trustedcertificates.yaml
+++ b/config/crd/patches/cainjection_in_trustedcertificates.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/webhook_in_trustedcertificates.yaml
+++ b/config/crd/patches/webhook_in_trustedcertificates.yaml
@@ -1,17 +1,17 @@
-# The following patch enables conversion webhook for CRD
-# CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: trustedcertificates.certificates.hpe.com
 spec:
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      ClientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/kubernetes/trustedcerts-operator/Chart.yaml
+++ b/kubernetes/trustedcerts-operator/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: trustedcerts-operator
-version: 0.8.0
+version: 0.8.1
 description: TrustedCerts Operator
 keywords:
   - trustedcerts

--- a/kubernetes/trustedcerts-operator/crds/certificates.hpe.com_trustedcertificates.yaml
+++ b/kubernetes/trustedcerts-operator/crds/certificates.hpe.com_trustedcertificates.yaml
@@ -1,6 +1,5 @@
-
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -17,80 +16,79 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      description: TrustedCertificates is the Schema for the trustedcertificates API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TrustedCertificatesSpec defines the desired state of TrustedCertificates
-          properties:
-            destinations:
-              items:
-                description: Destination Certificate destination struct
-                properties:
-                  config:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  name:
-                    maxLength: 255
-                    minLength: 1
-                    type: string
-                  type:
-                    pattern: (configmap|bss)
-                    type: string
-                required:
-                - config
-                - name
-                - type
-                type: object
-              minItems: 1
-              type: array
-            sources:
-              items:
-                description: Source Certificate source struct
-                properties:
-                  config:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  name:
-                    maxLength: 255
-                    minLength: 1
-                    type: string
-                  type:
-                    pattern: (http)
-                    type: string
-                required:
-                - config
-                - name
-                - type
-                type: object
-              minItems: 1
-              type: array
-          required:
-          - destinations
-          - sources
-          type: object
-        status:
-          description: TrustedCertificatesStatus defines the observed state of TrustedCertificates
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TrustedCertificates is the Schema for the trustedcertificates API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TrustedCertificatesSpec defines the desired state of TrustedCertificates
+            properties:
+              destinations:
+                items:
+                  description: Destination Certificate destination struct
+                  properties:
+                    config:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    name:
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    type:
+                      pattern: (configmap|bss)
+                      type: string
+                  required:
+                  - config
+                  - name
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+              sources:
+                items:
+                  description: Source Certificate source struct
+                  properties:
+                    config:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    name:
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    type:
+                      pattern: (http)
+                      type: string
+                  required:
+                  - config
+                  - name
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+            required:
+            - destinations
+            - sources
+            type: object
+          status:
+            description: TrustedCertificatesStatus defines the observed state of TrustedCertificates
+            type: object
+        type: object
     served: true
     storage: true
 status:


### PR DESCRIPTION
## Summary and Scope

Converts CRD's in use from v1beta1 to v1 apis for 1.22+ k8s compatibility. This should work on 1.16+ as the v1 api was introduced years ago.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMPET-6605
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Tested in vshastav2 grog(1.21)x and fearne (1.22)

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

