### PR TITLE
CASMPET-6904 update cert-manager api version

### DIFF
--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -2,7 +2,7 @@
 # More document can be found at https://docs.cert-manager.io
 # WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
 # breaking changes
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -10,7 +10,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/kubernetes/trustedcerts-operator/Chart.yaml
+++ b/kubernetes/trustedcerts-operator/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: trustedcerts-operator
-version: 0.8.2
+version: 0.9.0
 description: TrustedCerts Operator
 keywords:
   - trustedcerts


### PR DESCRIPTION
## Summary and Scope

The cert-manager API needs to be updated from v1alpha2 to v1. This is required for the cert-manager upgrade to v1.12.9 that is happening in CSM 1.6.

## Testing

I tested an upgrade of this chart manually. This will be included in an automated pipeline that is installing and upgrading all charts related to the cert-manager, istio, and k8s upgrade in CSM 1.6.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

